### PR TITLE
Single line comment highlight fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "license": "MIT",
     "icon": "images/icon.png",
-    "version": "1.2.2",
+    "version": "1.2.4",
     "engines": {
         "vscode": "^1.42.0"
     },

--- a/syntaxes/refal-5-lambda.tmLanguage.json
+++ b/syntaxes/refal-5-lambda.tmLanguage.json
@@ -17,7 +17,7 @@
 		{
 			"name": "comment.line.star.refal-5-lambda",
 			"comment": "Line comments",
-			"begin": "\\*",
+			"begin": "^\\*",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.comment.refal-5-lambda"


### PR DESCRIPTION
Был баг с подсветкой однострочного комментария. Однострочные комментарии должны начинаться с начала строки (https://bmstu-iu9.github.io/refal-5-lambda/3-basics.html).

> Помимо многострочных комментариев также допустимы однострочные — любая строка, начинающаяся со знака (**в первой колонке**) *, игнорируется компилятором.

Нашли вот тут: https://github.com/bmstu-iu9/refal-5-lambda/issues/288